### PR TITLE
Additional file replace pattern

### DIFF
--- a/fixSUPEE6788.php
+++ b/fixSUPEE6788.php
@@ -427,23 +427,23 @@ XML;
 				/**
 				 * Scan the file line-by-line for each pattern.
 				 */
-				$tmpOldPath = '';
-				$tmpNewPath = '';
+				$oldUrlPath = '';
+				$newUrlPath = '';
 				$checkLine  = 0;
 				foreach( $lines as $key => $line ) {
 					foreach( $this->_fileReplacePatterns as $pattern => $replacement ) {
 						if( strpos( $line, $pattern ) !== false ) {
 							$lines[ $key ] = str_replace( $pattern, $replacement, $line );
-						} else if ( strpos( $pattern, 'getUrl' ) !== false && strpos( $line, 'getUrl' ) !== false ) {
-							$tmpOldPath = substr( $pattern, strpos( $pattern, '(' ) + 2 );
-							$tmpNewPath = substr( $replacement, strpos( $replacement, '(' ) + 2 );
-							$checkLine  = $key + 1;
+						} else if ( $checkLine !== $key && strpos( $pattern, 'getUrl' ) !== false && strpos( $line, 'getUrl' ) !== false ) {
+							$oldUrlPath = substr( $pattern, strcspn($pattern, '"\'') + 1 );
+							$newUrlPath = substr( $replacement, strcspn($replacement, '"\'') + 1 );
+							$checkLine = ( strlen($oldUrlPath) > 0 && strlen($newUrlPath ) > 0 ) ? $key + 1 : 0;
 						}
 
-						if ( $checkLine > 0 && strpos( $line, $tmpOldPath ) !== false && $key == $checkLine ) {
-							$lines[ $key ]  = str_replace( $tmpOldPath, $tmpNewPath, $line );
-							$tmpOldPath     = '';
-							$tmpNewPath     = '';
+						if ( $checkLine > 0 && strpos( $line, $oldUrlPath ) !== false && $key == $checkLine ) {
+							$lines[ $key ]  = str_replace( $oldUrlPath, $newUrlPath, $line );
+							$oldUrlPath     = '';
+							$newUrlPath     = '';
 							$checkLine      = 0;
 						}
 					}

--- a/fixSUPEE6788.php
+++ b/fixSUPEE6788.php
@@ -427,10 +427,24 @@ XML;
 				/**
 				 * Scan the file line-by-line for each pattern.
 				 */
+				$tmpOldPath = '';
+				$tmpNewPath = '';
+				$checkLine  = 0;
 				foreach( $lines as $key => $line ) {
 					foreach( $this->_fileReplacePatterns as $pattern => $replacement ) {
 						if( strpos( $line, $pattern ) !== false ) {
 							$lines[ $key ] = str_replace( $pattern, $replacement, $line );
+						} else if ( strpos( $pattern, 'getUrl' ) !== false && strpos( $line, 'getUrl' ) !== false ) {
+							$tmpOldPath = substr( $pattern, strpos( $pattern, '(' ) + 2 );
+							$tmpNewPath = substr( $replacement, strpos( $replacement, '(' ) + 2 );
+							$checkLine  = $key + 1;
+						}
+
+						if ( $checkLine > 0 && strpos( $line, $tmpOldPath ) !== false && $key == $checkLine ) {
+							$lines[ $key ]  = str_replace( $tmpOldPath, $tmpNewPath, $line );
+							$tmpOldPath     = '';
+							$tmpNewPath     = '';
+							$checkLine      = 0;
 						}
 					}
 					


### PR DESCRIPTION
In some cases arguments for the method 'getUrl' are passed at different lines, this fix considers this moment.
For example:

``` php
Mage::helper('adminhtml')->getUrl(
   'frontname/adminhtml_controller/action',
   array('id' => $model->getId())
);
```
