### PR TITLE
Add modman and composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "rhoerr/supee-6788-toolbox",
+    "description": "Analysis/fix tool for extension and customization conflicts resulting from the Magento SUPEE-6788 patch.",
+    "type": "magento-module",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "ParadoxLabs, Inc.",
+            "email": "sales@paradoxlabs.com"
+        }
+    ],
+    "suggest": {
+        "magento-hackathon/magento-composer-installer": "Allows to manage this package as a dependency"
+    }
+}

--- a/fixSUPEE6788.php
+++ b/fixSUPEE6788.php
@@ -26,7 +26,7 @@
  * Support: http://support.paradoxlabs.com
  */
 
-require_once 'abstract.php';
+require_once dirname($_SERVER['SCRIPT_NAME']) . DIRECTORY_SEPARATOR . 'abstract.php';
 
 class Mage_Shell_PatchClass extends Mage_Shell_Abstract
 {

--- a/modman
+++ b/modman
@@ -1,0 +1,1 @@
+fixSUPEE6788.php  shell/fixSUPEE6788.php


### PR DESCRIPTION
When patching multiple sites with SUPEE-6788, it is convenient to add the `fixSUPEE6788.php` using modman or composer. This PR adds support for both modman and composer.

After merging this PR, the `fixSUPEE67888.php` script can be added to a composer enabled Magento project using the following commands:

``` sh
composer config repositories.supee-6788-toolbox vcs https://github.com/rhoerr/supee-6788-toolbox
composer require "rhoerr/supee-6788-toolbox:dev-master"
```

BTW If the package is registered at http://packages.firegento.com/, the first step can be left out.
